### PR TITLE
Emit sorting event

### DIFF
--- a/src/columns.js
+++ b/src/columns.js
@@ -278,6 +278,10 @@ export class Columns {
         }
 
         dt.sorting = true
+        
+        if (!init) {
+          dt.emit("datatable.sorting", column, dir)
+        }
 
         let rows = dt.data
         const alpha = []


### PR DESCRIPTION
Emit a sorting event when sorting begins. For large datasets there is a delay between click and the sort event. This event can be used to fill that time with some UI/UX.